### PR TITLE
Fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Edit the `config.py` file to customize the following settings:
 
 3. Use the file browser to select your Obsidian vault folder.
 
-4. Click on "Put Sirimal to Work" to extract tasks and save summary files to your obsidian vault.
+4. Click on "Put Sirimal to Work" to extract tasks and save summary files to your Obsidian vault.
 
 ## Creating a Desktop Shortcut (macOS Automator Application)
 You can create a one-click desktop app to launch Sirimal using Automator on macOS:


### PR DESCRIPTION
## Summary
- fix capitalization for 'Obsidian vault'

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6849399ec7688322a00dcc8e6325fffe