### PR TITLE
Handle notes without links

### DIFF
--- a/obsidian_agent.py
+++ b/obsidian_agent.py
@@ -120,9 +120,16 @@ def write_section_to_md(vault_path, section_name, items, vault_name):
         f.write(f"# {section_name}\n\n")
         for item in items:
             text, note_path = item
-            encoded_path = urllib.parse.quote(note_path)
-            obsidian_url = f"obsidian://open?vault={urllib.parse.quote(vault_name)}&file={encoded_path}"
-            f.write(f"- {text} [🔗]({obsidian_url})\n")
+            # Some tasks might not have an originating note (note_path is None).
+            # When no note is available, simply write the text without an Obsidian link.
+            if note_path:
+                encoded_path = urllib.parse.quote(note_path)
+                obsidian_url = (
+                    f"obsidian://open?vault={urllib.parse.quote(vault_name)}&file={encoded_path}"
+                )
+                f.write(f"- {text} [🔗]({obsidian_url})\n")
+            else:
+                f.write(f"- {text}\n")
     return file_path
 
 
@@ -141,7 +148,9 @@ def read_existing_summary(vault_path, section_name):
                 if line.startswith("- "):
                     # Remove the link if present
                     main_part = line[2:]
-                    # Try to extract note_path from the obsidian link
+                    # Try to extract note_path from the obsidian link. If no
+                    # link is present, note_path will remain None and we'll
+                    # store the task without a source note.
                     note_path = None
                     text = main_part
                     if "[🔗](obsidian://open?vault=" in main_part:
@@ -188,8 +197,9 @@ def process_and_update_summaries(vault_path, api_key, days=2, vault_name="kenny'
                 deduped[(norm_text, note_path)] = norm_text  # fallback to normalized text
         # Prepare list for writing
         final_list = [(text, note_path) for (norm_text, note_path), text in deduped.items()]
-        # Sort for consistency
-        final_list.sort(key=lambda x: (x[1], x[0]))
+        # Sort for consistency. `x[1]` may be None when a task has no link,
+        # so use an empty string as a fallback to avoid TypeError.
+        final_list.sort(key=lambda x: (x[1] or "", x[0]))
         write_section_to_md(vault_path, section, final_list, vault_name)
         new_counts[section] = len(final_list)
     return new_counts


### PR DESCRIPTION
## Summary
- handle case where a task has no note link
- allow sorting of tasks without note links
- clarify none handling when parsing existing summaries

## Testing
- `python -m py_compile obsidian_agent.py config.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_684939b3c57083228ffe8ad34214c8ab