### PR TITLE
Fix summary writing when note links missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,8 +5,13 @@ from obsidian_agent import list_recent_documents, extract_from_recent_notes, pro
 from dotenv import load_dotenv
 import urllib.parse
 load_dotenv()
-import os
-from config import DEFAULT_VAULT_PATH, DEFAULT_VAULT_NAME, AGENT_NAME, DAYS_TO_LOOK_BACK
+from config import (
+    DEFAULT_VAULT_PATH,
+    DEFAULT_VAULT_NAME,
+    AGENT_NAME,
+    DAYS_TO_LOOK_BACK,
+    SUMMARY_SAVE_PATH,
+)
 
 api_key = os.getenv("OPENAI_API_KEY")
 
@@ -58,8 +63,10 @@ def get_valid_directories(path):
         return []
 
 # Function to read summary section from markdown file
+
+
 def read_summary_section(vault_path, section_name):
-    sirimal_folder = os.path.join(vault_path, "10 - Sirimal")  # Or use SUMMARY_SAVE_PATH from config
+    sirimal_folder = os.path.join(vault_path, SUMMARY_SAVE_PATH)
     filename = f"{section_name.replace(' ', '_')}.md"
     file_path = os.path.join(sirimal_folder, filename)
     lines = []

--- a/obsidian_agent.py
+++ b/obsidian_agent.py
@@ -118,11 +118,13 @@ def write_section_to_md(vault_path, section_name, items, vault_name):
     file_path = os.path.join(sirimal_folder, filename)
     with open(file_path, "w", encoding="utf-8") as f:
         f.write(f"# {section_name}\n\n")
-        for item in items:
-            text, note_path = item
-            encoded_path = urllib.parse.quote(note_path)
-            obsidian_url = f"obsidian://open?vault={urllib.parse.quote(vault_name)}&file={encoded_path}"
-            f.write(f"- {text} [🔗]({obsidian_url})\n")
+        for text, note_path in items:
+            if note_path:
+                encoded_path = urllib.parse.quote(note_path)
+                obsidian_url = f"obsidian://open?vault={urllib.parse.quote(vault_name)}&file={encoded_path}"
+                f.write(f"- {text} [🔗]({obsidian_url})\n")
+            else:
+                f.write(f"- {text}\n")
     return file_path
 
 
@@ -189,7 +191,7 @@ def process_and_update_summaries(vault_path, api_key, days=2, vault_name="kenny'
         # Prepare list for writing
         final_list = [(text, note_path) for (norm_text, note_path), text in deduped.items()]
         # Sort for consistency
-        final_list.sort(key=lambda x: (x[1], x[0]))
+        final_list.sort(key=lambda x: ((x[1] or ""), x[0]))
         write_section_to_md(vault_path, section, final_list, vault_name)
         new_counts[section] = len(final_list)
     return new_counts


### PR DESCRIPTION
## Summary
- import SUMMARY_SAVE_PATH globally in `app.py`
- use SUMMARY_SAVE_PATH when reading summaries
- handle tasks without note links when writing sections
- avoid sort failures with `None` note paths

## Testing
- `python -m py_compile app.py obsidian_agent.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_684938731b9c83228fce96b15c08436a